### PR TITLE
Fix HTML entity in package description

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -3,7 +3,7 @@
   <name>estimateWB</name>
   <version>0.1.4</version>
   <date>2025-09-13</date>
-  <description>estimate the volume & weight of parts</description>
+  <description>estimate the volume &amp; weight of parts</description>
   <maintainer email="dev@erroronline.one">error on line 1</maintainer>
   <license file="LICENSE">LGPL-3.0-or-later</license>
   <icon>freecad/estimateWB/resources/icon.svg</icon>
@@ -16,7 +16,7 @@
       <subdirectory>./</subdirectory>
       <classname>estimateWB</classname>
       <name>estimateWB</name>
-      <description>estimate the volume & weight of parts</description>
+      <description>estimate the volume &amp; weight of parts</description>
       <version>0.1.4</version>
       <freecadmin>0.19.0</freecadmin>
       <!--depend>numpy</depend-->


### PR DESCRIPTION
In XML the ampersand is a reserved character, you have to use its predefined entity reference.