### PR TITLE
Add UTF-8 encoding to resource file openings

### DIFF
--- a/freecad/estimateWB/resources.py
+++ b/freecad/estimateWB/resources.py
@@ -16,7 +16,7 @@ def icon(name: str):
 
 
 with resources.as_file(resourcefiles / "materials.json") as path:
-	with open(str(path), "r") as jsonfile:
+	with open(str(path), "r", encoding="utf-8") as jsonfile:
 		""" preparing the material list with names and densities """
 		materials = json.loads(jsonfile.read().replace("\n", ""))
 
@@ -26,10 +26,10 @@ class language:
 		# try to open the language file according to FreeCAD settings, default to english
 		try:
 			language = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/General").GetString("Language")
-			with open(languagefiles / f"{language}.json", "r") as jsonfile:
+			with open(languagefiles / f"{language}.json", "r", encoding="utf-8") as jsonfile:
 				self.language = json.loads(jsonfile.read().replace("\n", ""))
 		except:
-			with open(languagefiles / "English.json", "r") as jsonfile:
+			with open(languagefiles / "English.json", "r", encoding="utf-8") as jsonfile:
 				self.language = json.loads(jsonfile.read().replace("\n", ""))
 	
 


### PR DESCRIPTION
See https://forum.freecad.org/viewtopic.php?t=101319 -- generally speaking it's advisable to always specify the encoding so you don't run into weird platform issues (more common on Windows than others, so I'm a little surprised at that report on the forums, but I think this will fix it).